### PR TITLE
Update lspci function output

### DIFF
--- a/gdb/gdb6
+++ b/gdb/gdb6
@@ -1980,11 +1980,10 @@ define lspci
 	printf "%p: pci%d:%d:%d:%d", $_dinfo, $_dinfo->cfg.domain, \
 	    $_dinfo->cfg.bus, $_dinfo->cfg.slot, $_dinfo->cfg.func
 	if ($_dinfo->cfg.dev != 0 && $_dinfo->cfg.dev->nameunit != 0)
-        printf " (%s) %s [%x:%x]", $_dinfo->cfg.dev->nameunit, \
-        $_dinfo->cfg.dev->desc, $_dinfo->cfg.vendor,
-        $_dinfo->cfg.device
+        printf " (%s) %s", $_dinfo->cfg.dev->nameunit, \
+            $_dinfo->cfg.dev->desc
 	end
-	printf "\n"
+	printf " [%x:%x]\n", $_dinfo->cfg.vendor, $_dinfo->cfg.device
 	set $_dinfo = $_dinfo->pci_links.stqe_next
     end
 end

--- a/gdb/gdb6
+++ b/gdb/gdb6
@@ -1980,7 +1980,9 @@ define lspci
 	printf "%p: pci%d:%d:%d:%d", $_dinfo, $_dinfo->cfg.domain, \
 	    $_dinfo->cfg.bus, $_dinfo->cfg.slot, $_dinfo->cfg.func
 	if ($_dinfo->cfg.dev != 0 && $_dinfo->cfg.dev->nameunit != 0)
-	    printf " (%s)", $_dinfo->cfg.dev->nameunit
+        printf " (%s) %s [%x:%x]", $_dinfo->cfg.dev->nameunit, \
+        $_dinfo->cfg.dev->desc, $_dinfo->cfg.vendor,
+        $_dinfo->cfg.device
 	end
 	printf "\n"
 	set $_dinfo = $_dinfo->pci_links.stqe_next


### PR DESCRIPTION
The current lspci display only the bus selector and device name. Add the
description, vendor and device id similar to the output of lspci -nn